### PR TITLE
Cancel timer

### DIFF
--- a/lib/slide_digital_clock.dart
+++ b/lib/slide_digital_clock.dart
@@ -40,6 +40,7 @@ class DigitalClock extends StatefulWidget {
 class _DigitalClockState extends State<DigitalClock> {
   DateTime _dateTime;
   ClockModel _clockModel;
+  Timer _timer;
 
   @override
   void initState() {
@@ -54,7 +55,7 @@ class _DigitalClockState extends State<DigitalClock> {
     _clockModel.minute = _dateTime.minute;
     _clockModel.second = _dateTime.second;
 
-    Timer.periodic(Duration(seconds: 1), (timer) {
+    _timer = Timer.periodic(Duration(seconds: 1), (timer) {
       _dateTime = DateTime.now();
       _clockModel.hour = _dateTime.hour;
       _clockModel.minute = _dateTime.minute;
@@ -62,6 +63,12 @@ class _DigitalClockState extends State<DigitalClock> {
 
       setState(() {});
     });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Fix 

E/flutter (20389): [ERROR:flutter/lib/ui/ui_dart_state.cc(148)] Unhandled Exception: setState() called after dispose(): _DigitalClockState#46295(lifecycle state: defunct, not mounted)
E/flutter (20389): This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
E/flutter (20389): The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
E/flutter (20389): This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
E/flutter (20389): #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1105:9)
E/flutter (20389): #1      State.setState (package:flutter/src/widgets/framework.dart:1140:6)
E/flutter (20389): #2      _DigitalClockState.initState.<anonymous closure> (package:slide_digital_clock/slide_digital_clock.dart:64:7)
E/flutter (20389): #3      _rootRunUnary (dart:async/zone.dart:1132:38)